### PR TITLE
feat: install bundler v1 and v2 side-by-side

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM renovate/ruby:2.6.0@sha256:b7b056404b8e82697beef1e0431db61917af7324d0f0c602
 
 USER root
 
-RUN gem install --no-document bundler -v 2.0.1
+RUN gem install --no-document bundler:2.1.4 bundler:1.17.3
 
 RUN chmod -R a+w /usr/local/lib/ruby/gems
 


### PR DESCRIPTION
see https://bundler.io/guides/bundler_2_upgrade.html

So we can support bundler v1 and v2